### PR TITLE
Bump chrono version to make the crate build with minimal versions on no-std environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ include = [
 travis-ci = { repository = "eldruin/rtcc-rs", branch = "master" }
 
 [dependencies]
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4.19", default-features = false }


### PR DESCRIPTION
`chrono <= 0.4.9` has build issue on `no-std` environment.
This commit make the crate build with the minimal versions (generated by `cargo +nightly update -Z minimal-versions`).