### PR TITLE
Expose DateTime type from chrono

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
-## [0.3.2] - 2024-03-22
-
 ### Added
 - Expose `DateTime` type to be used as replacement for some deprecated methods.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+## [0.3.2] - 2024-03-22
+
+### Added
+- Expose `DateTime` type to be used as replacement for some deprecated methods.
+
 ## [0.3.1] - 2024-02-01
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ include = [
 edition = "2021"
 
 [dependencies]
-chrono = { version = "0.4.33", default-features = false }
+chrono = { version = "0.4.35", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 #![deny(unsafe_code, missing_docs)]
 #![no_std]
 
-pub use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
+pub use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 
 /// Hours in either 12-hour (AM/PM) or 24-hour format
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Some methods on `NaiveDateTime` are deprecated and replaced with `DateTime`. So we need to expose `DateTime` to let library user use it.