### PR TITLE
Add optional support for defmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Added
+- Add optional `defmt-03` feature implementing `defmt::Format` on some types.
+
 ## [0.3.2] - 2024-03-25
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ edition = "2021"
 
 [dependencies]
 chrono = { version = "0.4.35", default-features = false }
+defmt = { version = "0.3", optional = true }
+
+[features]
+defmt-03 = ["dep:defmt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timeli
 
 /// Hours in either 12-hour (AM/PM) or 24-hour format
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Hours {
     /// AM [1-12]
     AM(u8),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,10 @@
 //! 6. Your system thinks it is `01:00:00`.
 //!
 //! The same applies to the date as well, as well as when calling setter methods.
+//!
+//! # Features
+//!
+//! The optional `defmt-03` feature implements [defmt::Format] on some types.
 
 #![deny(unsafe_code, missing_docs)]
 #![no_std]


### PR DESCRIPTION
This adds support for `defmt::Format` on some types.